### PR TITLE
Add padding and box-sizing to .ap style

### DIFF
--- a/src/scss/core/_styles.scss
+++ b/src/scss/core/_styles.scss
@@ -283,6 +283,8 @@ button.ql-table[value="append-col"]::after { content: "COLS+"; }
     background-image: url(../sheet_apple_20.png);
     background-repeat: no-repeat;
     text-indent: -999px;
+    padding-left: 20px;
+    box-sizing: border-box;
 }
 
 .ap-copyright {


### PR DESCRIPTION
In safari emoji renders as black rectangle, background-image seems to be ignored.
Solution was found here: https://css-tricks.com/replace-the-image-in-an-img-with-css/