### PR TITLE
Updating format-emoji-blot.js so emojis can be rendered from a DeltaOps object

### DIFF
--- a/src/emoji-map.js
+++ b/src/emoji-map.js
@@ -1,0 +1,9 @@
+import emojiList from "./emoji-list";
+
+const emojiMap = {};
+
+emojiList.forEach((emojiListObject) => {
+    emojiMap[emojiListObject.name] = emojiListObject;
+});
+
+export default emojiMap;

--- a/src/format-emoji-blot.js
+++ b/src/format-emoji-blot.js
@@ -1,4 +1,5 @@
 import Quill from 'quill';
+import emojiMap from "./emoji-map";
 
 const Embed = Quill.import('blots/embed');
 
@@ -6,18 +7,30 @@ class EmojiBlot extends Embed {
   static create(value) {
     let node = super.create();
     if (typeof value === 'object') {
-      node.setAttribute('data-name', value.name);
-      let emojiSpan = document.createElement('span');
-      emojiSpan.classList.add(this.emojiClass);
-      emojiSpan.classList.add(this.emojiPrefix + value.name);
-      emojiSpan.innerText = String.fromCodePoint('0x' + value.unicode);
-      node.appendChild(emojiSpan);
+    
+      EmojiBlot.buildSpan(value, node);
+    } else if (typeof value === "string") {
+      const valueObj = emojiMap[value];
+
+      if (valueObj) {
+        EmojiBlot.buildSpan(valueObj, node);
+      }
     }
+
     return node;
   }
 
   static value(node) {
-    return node.contentText;
+    return node.dataset.name;
+  }
+
+  static buildSpan(value, node) {
+    node.setAttribute('data-name', value.name);
+    let emojiSpan = document.createElement('span');
+    emojiSpan.classList.add(this.emojiClass);
+    emojiSpan.classList.add(this.emojiPrefix + value.name);
+    emojiSpan.innerText = String.fromCodePoint('0x' + value.unicode);
+    node.appendChild(emojiSpan);
   }
 }
 


### PR DESCRIPTION
This should address https://github.com/contentco/quill-emoji/issues/37. I believe the issue is occurring b/c the current version of quill-emoji can't create a node from the value returned by `EmojiBlot.value()`