### PR TITLE
Ensuring that tabs in the textarea module are the only elements retur…

### DIFF
--- a/src/module-textarea-emoji.js
+++ b/src/module-textarea-emoji.js
@@ -68,14 +68,19 @@ class TextAreaEmoji extends Module {
                 tabElementHolder.appendChild(tabElement);
                 let emojiFilter = document.querySelector('.filter-'+emojiType.name);
                 emojiFilter.addEventListener('click',function(){
-                    let tab = document.querySelector('.active');
+                    const emojiContainer = document.getElementById("textarea-emoji");
+                    const tab = emojiContainer && emojiContainer.querySelector('.active');
+                    
                     if (tab) {
                         tab.classList.remove('active');
                     }
+
                     emojiFilter.classList.toggle('active');
-                     while (panel.firstChild) {
+                    
+                    while (panel.firstChild) {
                         panel.removeChild(panel.firstChild);
                     }
+
                     let type = emojiFilter.dataset.filter;
                     fn_emojiElementsToPanel(type,panel,innerQuill);
                 })


### PR DESCRIPTION
…ned by the query for elements with the class 'active'

If there are other elements on the DOM with the class 'active', the textarea module wouldn't change tabs properly. This change should address that problem. 