### PR TITLE
adding binding so autocomplete works in firefox

### DIFF
--- a/src/module-emoji.js
+++ b/src/module-emoji.js
@@ -48,6 +48,11 @@ class ShortNameEmoji extends Module {
     }, this.triggerPicker.bind(this));
 
     quill.keyboard.addBinding({
+      key: 59,  // gecko based browsers (firefox) use 59 as the keycode for semicolon, which makes a colon character when combined with shift
+      shiftKey: true,
+    }, this.triggerPicker.bind(this));
+
+    quill.keyboard.addBinding({
       key: 39,  // ArrowRight
       collapsed: true,
       format: ["emoji-shortname"]


### PR DESCRIPTION
This should address https://github.com/contentco/quill-emoji/issues/43 and https://github.com/contentco/quill-emoji/issues/21.