### PR TITLE
fix(emoji-scss): remove bad thumbsup rule

### DIFF
--- a/src/scss/core/_emoji.scss
+++ b/src/scss/core/_emoji.scss
@@ -2096,7 +2096,7 @@
   background-position: -280px -780px;
 }
     
-.ap-+1, .ap-thumbsup {
+.ap-thumbsup {
   background-position: -300px -80px;
 }
     


### PR DESCRIPTION
.ap-thumbsup doesn't have a CSS rule because of illegal character ``+`` in class ``ap-+1``
```
.ap-+1, .ap-thumbsup {
```

Thumbs up emojis appear as copyright symbols instead: ©️ 

**Changes proposed in this pull request:**
Remove bad class from SCSS rule

**Fixes:** #38

