### PR TITLE
fix(textarea,toolbar): set text caret after emoji

### DIFF
--- a/src/module-textarea-emoji.js
+++ b/src/module-textarea-emoji.js
@@ -157,6 +157,7 @@ function fn_emojiElementsToPanel(type,panel,quill){
                 // quill.setSelection(range.index + customButton.innerHTML.length, 0);
                 // range.index = range.index + customButton.innerHTML.length;
                 quill.insertEmbed(range.index, 'emoji', emoji);
+                setTimeout(() => quill.setSelection(range.index + 1), 0);
                 fn_close();
             });
         }

--- a/src/module-toolbar-emoji.js
+++ b/src/module-toolbar-emoji.js
@@ -179,6 +179,7 @@ function fn_emojiElementsToPanel(type,panel,quill){
         let emoji_icon_html =makeElement("span", {className: "ico", innerHTML: ''+emoji.code_decimal+' ' });
         let emoji_icon = emoji_icon_html.innerHTML;
         quill.insertEmbed(range.index, 'emoji', emoji);
+        setTimeout(() => quill.setSelection(range.index + 1), 0);
         fn_close();
       });
     }


### PR DESCRIPTION
When an emoji is inserted via the toolbar or textarea controls, the text caret (not visible due to #49, but I have a PR coming to fix that as well) is positioned before the inserted emoji. Subsequent emoji insertions or keyboard input occur before the inserted emoji as opposed to after.

**Changes proposed in this pull request:**
Set text caret position to just after inserted emoji using the ``setTimeout`` technique as is done with completions in [``module-emoji.js``](https://github.com/contentco/quill-emoji/blob/master/src/module-emoji.js#L240)

**Fixes:** bug described in this PR.  No "official" issue is opened for this but I can make one if desired.