### PR TITLE
fix(styles-scss): make ql-emojiblot inline-block

### DIFF
--- a/src/scss/core/_styles.scss
+++ b/src/scss/core/_styles.scss
@@ -277,6 +277,6 @@ button.ql-table[value="append-col"]::after { content: "COLS+"; }
 }
 
 .ql-emojiblot {
-  display: inline-flex;
-  align-items: center;
+  display: inline-block;
+  vertical-align: text-top;
 }


### PR DESCRIPTION
Text caret/cursor immediately before or after an emoji is not visible.

**Changes proposed in this pull request:**
Don't display ``.ql-emojiblot`` as ``inline-flex``, instead use ``inline-block``, which quill and contenteditable handle better with the text caret/cursor.

Also set ``vertical-align: text-top`` to visually mimic ``align-items: center``. See image below for comparison:

![quill-emoji-issue-49](https://user-images.githubusercontent.com/13917896/50178415-71f85a80-02d2-11e9-8d03-9ee86e163dea.png)

**Fixes:** #49