### PR TITLE
feat: Stricter querySelector for toolbar tab changes

### DIFF
--- a/src/module-toolbar-emoji.js
+++ b/src/module-toolbar-emoji.js
@@ -113,9 +113,9 @@ function fn_showEmojiPalette(quill) {
     tabElement.dataset.filter = emojiType.type;
     tabElementHolder.appendChild(tabElement);
 
-    let emojiFilter = document.querySelector('.filter-' + emojiType.name);
+    let emojiFilter = tabElementHolder.querySelector('.filter-' + emojiType.name);
     emojiFilter.addEventListener('click', function () {
-      let tab = document.querySelector('.active');
+      let tab = tabElementHolder.querySelector('.active');
       if (tab) {
         tab.classList.remove('active');
       }
@@ -128,7 +128,7 @@ function fn_showEmojiPalette(quill) {
 
 function fn_emojiPanelInit(panel, quill) {
   fn_emojiElementsToPanel('p', panel, quill);
-  document.querySelector('.filter-people').classList.add('active');
+  document.querySelector('#emoji-palette #tab-toolbar .filter-people').classList.add('active');
 }
 
 function fn_emojiElementsToPanel(type, panel, quill) {


### PR DESCRIPTION
**Problem**

When switching tabs in the emoji toolbar, it used `document.querySelector('.active')` to select the tab element. However, this is very generic and caused bugs in my application, because the quill editor is inside another tab view, also using the class name `active`.

**Solution**

I added some further specification, to make sure the querySelector always selects the correct element.