### PR TITLE
Mobile responsiveness - ensure palette does not start off screen

### DIFF
--- a/src/module-toolbar-emoji.js
+++ b/src/module-toolbar-emoji.js
@@ -61,7 +61,7 @@ function fn_showEmojiPalette(quill) {
   const editorBounds = quill.container.getBoundingClientRect();
   const selectionCenter = (selectionBounds.left + selectionBounds.right) / 2;
   const selectionMiddle = (selectionBounds.top + selectionBounds.bottom) / 2;
-  const paletteLeft = editorBounds.left + selectionCenter + paletteWidthAndHeight <= document.documentElement.clientWidth ? selectionCenter : editorBounds.left - paletteWidthAndHeight;
+  const paletteLeft = editorBounds.left + selectionCenter + paletteWidthAndHeight <= document.documentElement.clientWidth ? selectionCenter : Math.max(editorBounds.left - paletteWidthAndHeight, 0);
   const paletteTop = editorBounds.top + selectionMiddle + paletteWidthAndHeight + 10 <= document.documentElement.clientHeight ? selectionMiddle + 10 :
     editorBounds.top + selectionMiddle - paletteWidthAndHeight - 10 >= 0 ? selectionMiddle - paletteWidthAndHeight - 10 :
       document.documentElement.clientHeight - paletteWidthAndHeight - editorBounds.top;


### PR DESCRIPTION
On small screens, depending on where the cursor is located, the emoji palette may open off screen, like this:

![image](https://github.com/KeithGillette/quill-emoji/assets/2145098/2205359c-80ba-4ce8-846a-59999c2bf448)

Limit to zero ensures the palette can't go too far left:

![image](https://github.com/KeithGillette/quill-emoji/assets/2145098/bf60ab88-fe37-48bf-8c72-73321a09ad5f)

Unfortunately, I am unable to get `yarn` or `yarn build` to run locally without error. If someone else could build to update `/dist`, that would be great